### PR TITLE
Load autocomplete only on display of Char widget

### DIFF
--- a/src/view/form.js
+++ b/src/view/form.js
@@ -1498,7 +1498,7 @@ function eval_pyson(value){
                 'type': 'text',
                 'class': 'form-control input-sm'
             }).appendTo(this.group);
-            if (attributes.autocomplete) {
+            if (!jQuery.isEmptyObject(attributes.autocomplete)) {
                 this.datalist = jQuery('<datalist/>').appendTo(this.el);
                 this.datalist.uniqueId();
                 this.input.attr('list', this.datalist.attr('id'));
@@ -1532,15 +1532,22 @@ function eval_pyson(value){
             Sao.View.Form.Char._super.display.call(this, record, field);
             if (this.datalist) {
                 this.datalist.children().remove();
-                var selection = [];
-                if (record) {
-                    selection = record.autocompletion[this.field_name] || [];
+                var set_autocompletion = function() {
+                    var selection = [];
+                    if (record) {
+                        selection = record.autocompletion[this.field_name] || [];
+                    }
+                    selection.forEach(function(e) {
+                        jQuery('<option/>', {
+                            'value': e
+                        }).appendTo(this.datalist);
+                    }.bind(this));
+                }.bind(this);
+                if (record && !(this.field_name in record.autocompletion)) {
+                    record.do_autocomplete(this.field_name).done(set_autocompletion);
+                } else {
+                    set_autocompletion();
                 }
-                selection.forEach(function(e) {
-                    jQuery('<option/>', {
-                        'value': e
-                    }).appendTo(this.datalist);
-                }.bind(this));
             }
 
             // Set size


### PR DESCRIPTION
Keeping the autocomplete always up to date is very expensive especially
for large list because the method is called once per field for each
record. Indeed autocomplete is only needed when the Char widget is
displayed. So we could just load it at display and keep it up to date
when fields are changed.