### PR TITLE
fix eval date

### DIFF
--- a/src/pyson.js
+++ b/src/pyson.js
@@ -350,6 +350,8 @@
     Sao.PYSON.Equal.eval_ = function(value, context) {
         if (value.s1 instanceof Array  && value.s2 instanceof Array) {
             return Sao.common.compare(value.s1, value.s2);
+        } else if (moment.isMoment(value.s1) && moment.isMoment(value.s2)) {
+            return value.s1.format() == value.s2.format();
         } else {
             return value.s1 == value.s2;
         }

--- a/src/pyson.js
+++ b/src/pyson.js
@@ -141,17 +141,11 @@
     });
 
     Sao.PYSON.Eval.eval_ = function(value, context) {
-        var ret;
         if (value.v in context) {
-            ret = context[value.v];
+            return context[value.v];
         } else {
-            ret = value.d;
+            return value.d;
         }
-        if(ret && ret._isAMomentObject){
-            var encoder = new Sao.PYSON.Encoder({});
-            ret = encoder.encode(ret);
-        }
-        return ret;
     };
     Sao.PYSON.Eval.init_from_object = function(obj) {
         return new Sao.PYSON.Eval(obj.v, obj.d);

--- a/src/pyson.js
+++ b/src/pyson.js
@@ -141,11 +141,17 @@
     });
 
     Sao.PYSON.Eval.eval_ = function(value, context) {
+        var ret;
         if (value.v in context) {
-            return context[value.v];
+            ret = context[value.v];
         } else {
-            return value.d;
+            ret = value.d;
         }
+        if(ret && ret._isAMomentObject){
+            var encoder = new Sao.PYSON.Encoder({});
+            ret = encoder.encode(ret);
+        }
+        return ret;
     };
     Sao.PYSON.Eval.init_from_object = function(obj) {
         return new Sao.PYSON.Eval(obj.v, obj.d);


### PR DESCRIPTION
![momentcompare](https://user-images.githubusercontent.com/10531595/36848093-7f9d0c88-1d60-11e8-84d8-ebe05e5922e0.png)
Voilà ce qu'essayais de faire sao avant le fix maintenant il traite un objet Date géré par pyson.

Le fix n'est peut etre pas au bon endroit.
Il y a une section de code lors de l'appel a expr_eval (*model.js:1108*)

On fait appel au context qui lui renvoie les dates au format moment.js et c'est ça qui fait planter les evals des dates. 