### PR TITLE
tree:  prevent call to focus if widget does not define it

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+* BUG#8720 Prevent call to focus when not defined on widget
 * BUG#8703 Show visible boolean extra data
 * BUG#8705 Add white color for link
 * BUG#8706 Remove link when line is not selected

--- a/src/view/tree.js
+++ b/src/view/tree.js
@@ -1357,7 +1357,7 @@
                     }
                 }
             }
-            if (focus_widget) {
+            if (focus_widget && focus_widget.focus) {
                 focus_widget.focus();
             }
         },

--- a/src/view/tree.js
+++ b/src/view/tree.js
@@ -1357,6 +1357,7 @@
                     }
                 }
             }
+            // JMO: work around BUG#8720
             if (focus_widget && focus_widget.focus) {
                 focus_widget.focus();
             }


### PR DESCRIPTION

Fix #8720