### PR TITLE
Add CodeMirror support to sourceview widget

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,8 @@
     "c3": "^0.4",
     "papaparse": "^4.1",
     "fullcalendar": "^3.0",
-    "mousetrap": "^1.6"
+    "mousetrap": "^1.6",
+    "codemirror": "^5.38"
   },
   "devDependencies": {
     "qunit": "^1.18"

--- a/index.html
+++ b/index.html
@@ -23,12 +23,14 @@ this repository contains the full copyright notices and license terms. -->
         <script type="text/javascript" src="bower_components/mousetrap/mousetrap.min.js"></script>
         <script type="text/javascript" src="bower_components/codemirror/lib/codemirror.js"></script>
         <script type="text/javascript" src="bower_components/codemirror/mode/python/python.js"></script>
+        <script type="text/javascript" src="bower_components/codemirror/addon/lint/lint.js"></script>
 
         <link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.min.css">
         <link rel="stylesheet" href="bower_components/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css">
         <link rel="stylesheet" href="bower_components/c3/c3.min.css">
         <link rel="stylesheet" href="bower_components/fullcalendar/dist/fullcalendar.min.css">
         <link rel="stylesheet" href="bower_components/codemirror/lib/codemirror.css">
+        <link rel="stylesheet" href="bower_components/codemirror/addon/lint/lint.css">
         <link rel="stylesheet" href="offcanvas.css">
 
         <script type="text/javascript" src="dist/tryton-sao.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -21,11 +21,14 @@ this repository contains the full copyright notices and license terms. -->
         <script type="text/javascript" src="bower_components/fullcalendar/dist/fullcalendar.min.js"></script>
         <script type="text/javascript" src="bower_components/fullcalendar/dist/locale-all.js"></script>
         <script type="text/javascript" src="bower_components/mousetrap/mousetrap.min.js"></script>
+        <script type="text/javascript" src="bower_components/codemirror/lib/codemirror.js"></script>
+        <script type="text/javascript" src="bower_components/codemirror/mode/python/python.js"></script>
 
         <link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.min.css">
         <link rel="stylesheet" href="bower_components/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css">
         <link rel="stylesheet" href="bower_components/c3/c3.min.css">
         <link rel="stylesheet" href="bower_components/fullcalendar/dist/fullcalendar.min.css">
+        <link rel="stylesheet" href="bower_components/codemirror/lib/codemirror.css">
         <link rel="stylesheet" href="offcanvas.css">
 
         <script type="text/javascript" src="dist/tryton-sao.min.js"></script>

--- a/src/coopengo.less
+++ b/src/coopengo.less
@@ -1,3 +1,7 @@
 div.readonly div.CodeMirror-sizer {
     background-color: lightgrey;
 }
+
+div.CodeMirror {
+    height: 460px;
+}

--- a/src/coopengo.less
+++ b/src/coopengo.less
@@ -1,0 +1,3 @@
+div.readonly div.CodeMirror-sizer {
+    background-color: lightgrey;
+}

--- a/src/sao.js
+++ b/src/sao.js
@@ -306,9 +306,11 @@ var Sao = {};
         Sao.i18n.setlang().always(function() {
             Sao.Session.get_credentials()
                 .then(function(session) {
+                    console.log('set session');
                     Sao.Session.current_session = session;
                     return session.reload_context();
                 }).then(Sao.get_preferences).then(function(preferences) {
+                    console.log('set preferences');
                     Sao.menu(preferences);
                     Sao.user_menu(preferences);
                 });

--- a/src/sao.js
+++ b/src/sao.js
@@ -306,11 +306,9 @@ var Sao = {};
         Sao.i18n.setlang().always(function() {
             Sao.Session.get_credentials()
                 .then(function(session) {
-                    console.log('set session');
                     Sao.Session.current_session = session;
                     return session.reload_context();
                 }).then(Sao.get_preferences).then(function(preferences) {
-                    console.log('set preferences');
                     Sao.menu(preferences);
                     Sao.user_menu(preferences);
                 });

--- a/src/sao.less
+++ b/src/sao.less
@@ -1,5 +1,6 @@
 @import "variables";
 @import "mixins";
+@import "src/coopengo.less";
 
 #tablist > li > a {
     border: 0;

--- a/src/view/form.js
+++ b/src/view/form.js
@@ -1390,6 +1390,11 @@ function eval_pyson(value){
             field.set_client(record, this.codeMirror.getValue());
         },
         set_readonly: function(readonly) {
+            if (readonly) {
+                this.sc_editor.addClass('readonly');
+            } else {
+                this.sc_editor.removeClass('readonly');
+            }
             this.codeMirror.setOption('readOnly', readonly);
         }
     });

--- a/src/view/form.js
+++ b/src/view/form.js
@@ -1265,7 +1265,9 @@ function eval_pyson(value){
             }).appendTo(jQuery('<div/>', {
                 'class': 'panel-heading'
             }).appendTo(this.sc_editor));
-            this.toolbar.css('width', '100%');
+            this.toolbar.css({
+                width: '100%',
+            });
 
             add_buttons([
                     {
@@ -1282,7 +1284,7 @@ function eval_pyson(value){
             var input = jQuery('<textarea/>', {
             }).appendTo(jQuery('<div/>', {
                 'class': 'panel-body'
-            }).appendTo(this.sc_editor).css('padding', '5px'));
+            }).appendTo(this.sc_editor).css('min-height', '490px'));
             this.codeMirror = CodeMirror.fromTextArea(input[0], {
                 mode: {
                     name: 'python',
@@ -1316,7 +1318,7 @@ function eval_pyson(value){
             this.tbody = jQuery('<tbody/>').appendTo(this.table);
             this.tbody.css({
                 'display': 'block',
-                'height': '35em'
+                'height': '490px'
             });
         },
         display: function(record, field){

--- a/src/view/form.js
+++ b/src/view/form.js
@@ -1207,8 +1207,15 @@ function eval_pyson(value){
             });
             this.tree_data_field = attributes.context_tree || null;
 
-            this.init_tree(4);
-            this.init_editor(8);
+            var editor_width;
+            if (this.tree_data_field) {
+                this.init_tree(4);
+                editor_width = 8;
+            }
+            else {
+                editor_width = 12;
+            }
+            this.init_editor(editor_width);
 
             this.tree_data = [];
             this.tree_elements = [];
@@ -1217,10 +1224,20 @@ function eval_pyson(value){
         },
         init_editor: function(width){
             var button_apply_command = function(evt) {
-                var success = document.execCommand(evt.data);
-                // if (!success)
-                //     my_custom_exec(evt.data);
-            };
+                console.log(evt.data);
+                var cmDoc = this.codeMirror.getDoc();
+                switch (evt.data) {
+                    case 'undo':
+                        cmDoc.undo();
+                        break;
+                    case 'redo':
+                        cmDoc.redo();
+                        break;
+                    case 'check':
+                        console.log('todo');
+                        break;
+                }
+            }.bind(this);
 
             var add_buttons = function(buttons) {
                 var i, properties, button;
@@ -1263,15 +1280,20 @@ function eval_pyson(value){
                         'command': 'check'
                     }]);
 
-            this.input = jQuery('<div/>', {
-                'class': 'richtext pre',
-                'contenteditable': true
+            var input = jQuery('<textarea/>', {
             }).appendTo(jQuery('<div/>', {
                 'class': 'panel-body'
             }).appendTo(this.sc_editor).css('padding', '5px'));
-            this.input.css({
-                'height': '33em',
-                'overflow': 'auto'
+            this.codeMirror = CodeMirror.fromTextArea(input[0], {
+                mode: {
+                    name: 'python',
+                    version: 2,
+                    singleLineStringErrors: false
+                },
+                lineNumbers: true,
+                indentUnit: 4,
+                indentWithTabs: false,
+                matchBrackets: true
             });
         },
         init_tree: function(width){
@@ -1296,13 +1318,10 @@ function eval_pyson(value){
             Sao.View.Form.Source._super.display.call(this, record, field);
 
             var display_code = function(str){
-                var lines = str.split('\n');
-                var ret = [];
-                for (var i in lines){
-                    jQuery('<div/>').appendTo(this.input).text(lines[i]).css(
-                        'font-family', 'monospace'
-                    );
-                }
+                this.codeMirror.setValue(str);
+                // Call refresh because when codemirror is initialized it's not
+                // displayed and its computation are off
+                this.codeMirror.refresh();
             }.bind(this);
 
             var display_tree = function(){
@@ -1324,7 +1343,6 @@ function eval_pyson(value){
             var value = field.get_client(record);
             if (value != this.value){
                 this.value = value;
-                this.input.empty();
                 display_code(this.value);
             }
 
@@ -1369,13 +1387,10 @@ function eval_pyson(value){
             }
         },
         set_value: function(record, field){
-            var content = [];
-            this.input.children('div').each(function(){
-                if (content.length > 0)
-                    content[content.length -1] = content[content.length -1] + '\n';
-                content.push(jQuery(this).text());
-            });
-            field.set_client(record, content.join(''));
+            field.set_client(record, this.codeMirror.getValue());
+        },
+        set_readonly: function(readonly) {
+            this.codeMirror.setOption('readOnly', readonly);
         }
     });
 

--- a/src/view/form.js
+++ b/src/view/form.js
@@ -1224,7 +1224,6 @@ function eval_pyson(value){
         },
         init_editor: function(width){
             var button_apply_command = function(evt) {
-                console.log(evt.data);
                 var cmDoc = this.codeMirror.getDoc();
                 switch (evt.data) {
                     case 'undo':
@@ -1234,7 +1233,7 @@ function eval_pyson(value){
                         cmDoc.redo();
                         break;
                     case 'check':
-                        console.log('todo');
+                        this.codeMirror.performLint();
                         break;
                 }
             }.bind(this);
@@ -1293,7 +1292,13 @@ function eval_pyson(value){
                 lineNumbers: true,
                 indentUnit: 4,
                 indentWithTabs: false,
-                matchBrackets: true
+                matchBrackets: true,
+                gutters: ["CodeMirror-lint-markers"],
+                lint: {
+                    lintOnChange: false,
+                    getAnnotations: this.pythonLinter,
+                    async: true
+                }
             });
         },
         init_tree: function(width){
@@ -1396,6 +1401,20 @@ function eval_pyson(value){
                 this.sc_editor.removeClass('readonly');
             }
             this.codeMirror.setOption('readOnly', readonly);
+        },
+        pythonLinter: function(doc, updateLint, options, editor) {
+            console.log('pythonLinter called');
+            updateLint([{
+                message: 'Error',
+                severity: 'error',
+                from: CodeMirror.Pos(0, 0), // First Line, First column
+                to: CodeMirror.Pos(0, 4) // First Line, 4th column
+            }, {
+                message: 'Warning',
+                severity: 'warning',
+                from: CodeMirror.Pos(1, 0),
+                to: CodeMirror.Pos(1, 1)
+            }]);
         }
     });
 


### PR DESCRIPTION
As discussed with Jérémy the linting could be done with a call to an endpoint on the server.
I have added a small example in the 'pythonLinter' function you just have to put your call to the endpoint there (doc contains the code) and call updateLint in the callback of the request.