### PR TITLE
Only set width 100% of input-form inside dict

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+* BUG#9446 Only set width 100 to inputfrom inside dict
 * BUG#8756 Only open link when using ctrl key
 * BUG#9035 Remove checkbox for always ignoring warnings
 * FEA#8271 Add support of expand attribute on group tag

--- a/theme/coog/elements/inputs.less
+++ b/theme/coog/elements/inputs.less
@@ -30,7 +30,7 @@
     @input-multi-border:        1px;
 /* style */
 /* sizes */
-.input-group.input-group-sm {
+[class^="dict-"] > .input-group.input-group-sm {
     width: 100%;
 }
 


### PR DESCRIPTION
Fix #9446
![image](https://user-images.githubusercontent.com/10531595/42893055-a7477690-8ab3-11e8-9288-0c94189a1282.png)
