### PR TITLE
Wait the promises from set_on_change before calling display

### DIFF
--- a/src/screen.js
+++ b/src/screen.js
@@ -1868,10 +1868,11 @@
                         var values = record._get_on_change_args(args);
                         return record.model.execute(attributes.name, [values],
                             this.context).then(function(changes) {
-                            record.set_on_change(changes);
-                            record.group.root_group.screens.forEach(
-                                function(screen) {
-                                    screen.display();
+                            record.set_on_change(changes).then(function() {
+                                record.group.root_group().screens.forEach(
+                                    function(screen) {
+                                        screen.display();
+                                    });
                             });
                         });
                     } else {


### PR DESCRIPTION
The instance button call set_on_change to set the new value but some fields
like xxx2Many returns a promises. We must wait for them before calling display
otherwise the new values will not be rendered.

issue8595