### PR TITLE
Set readonly both inputs of numeric dict fields

### DIFF
--- a/src/view/form.js
+++ b/src/view/form.js
@@ -5283,6 +5283,10 @@ function eval_pyson(value){
                 this.input_text.val('');
             }
         },
+        set_readonly: function(readonly) {
+            Sao.View.Form.Dict.Float._super.set_readonly.call(this, readonly);
+            this.input_text.prop('disabled', readonly);
+        }
     });
 
     Sao.View.Form.Dict.Numeric = Sao.class_(Sao.View.Form.Dict.Float, {


### PR DESCRIPTION
Fix #18089